### PR TITLE
Add Hipchat API V2 support

### DIFF
--- a/cabot_alert_hipchat/models.py
+++ b/cabot_alert_hipchat/models.py
@@ -76,15 +76,25 @@ class HipchatAlert(AlertPlugin):
         room = env.get('HIPCHAT_ALERT_ROOM')
         api_key = env.get('HIPCHAT_API_KEY')
         url = env.get('HIPCHAT_URL')
+        api_version = env.get('HIPCHAT_API_VERSION')
+        url_v2 = env.get('HIPCHAT_V2_URL')
 
-        resp = requests.post(url + '?auth_token=' + api_key, data={
-            'room_id': room,
-            'from': sender[:15],
-            'message': message,
-            'notify': 1,
-            'color': color,
-            'message_format': 'text',
-        })
+        if api_version == '2':
+            resp = requests.post(url_v2 + room + '/notification' + '?auth_token=' + api_key, data={
+                'message': message,
+                'notify': 'true',
+                'color': color,
+                'message_format': 'text',
+            })
+        else:
+            resp = requests.post(url + '?auth_token=' + api_key, data={
+                'room_id': room,
+                'from': sender[:15],
+                'message': message,
+                'notify': 1,
+                'color': color,
+                'message_format': 'text',
+            })
 
 class HipchatAlertUserData(AlertPluginUserData):
     name = "Hipchat Plugin"


### PR DESCRIPTION
Patch to add hipchat api v2 support. Keeps backwards compatibility with the old API without having to update existing Cabot configs, hence adding HIPCHAT_V2_URL.

Cabot needs the following variables added to the conf file:
HIPCHAT_API_VERSION=2
HIPCHAT_V2_URL=https://api.hipchat.com/v2/room/

Thanks!
